### PR TITLE
Update SilentCleanupWinDirBOF.c

### DIFF
--- a/SilentCleanupWinDir/src/SilentCleanupWinDirBOF.c
+++ b/SilentCleanupWinDir/src/SilentCleanupWinDirBOF.c
@@ -291,6 +291,7 @@ int go(char * args, unsigned long length) {
     KERNEL32$Sleep(30000);
 
     FileCleanup:
+    ; 
     // delete exe from created directory
     int result = KERNEL32$DeleteFileA(targetBinLocation);
     if (result != 0) {


### PR DESCRIPTION
Correction error: a label can only be part of a statement and a declaration is not a statement